### PR TITLE
Organize theme structure for custom post types

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,39 +9,12 @@ function astra_child_enqueue_styles() {
     wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
     wp_enqueue_style( 'child-style',
         get_stylesheet_directory_uri() . '/style.css',
-        array('parent-style')
+        array( 'parent-style' )
     );
 }
 /*
  * Your code goes below
  */
 
-// Showroom Post Type
- function success_story_posts() {
-   $labels = array(
-     'name'               => _x( 'Success Story', 'post type general name' ),
-     'singular_name'      => _x( 'Success Story', 'post type singular name' ),
-     'add_new'            => _x( 'Add New', 'Success Story' ),
-     'add_new_item'       => __( 'Add New Success Story' ),
-     'edit_item'          => __( 'Edit Success Story' ),
-     'new_item'           => __( 'New Success Story' ),
-     'all_items'          => __( 'All Success Stories' ),
-     'view_item'          => __( 'View Success Stories' ),
-     'search_items'       => __( 'Search Success Stories' ),
-     'not_found'          => __( 'No Success Stories found' ),
-     'not_found_in_trash' => __( 'No Success Stories found in the Trash' ), 
-     'parent_item_colon'  => '',
-     'menu_name'          => 'Success Stories'
-   );
-   $args = array(
-     'labels'        => $labels,
-     'description'   => 'Our Success Stories',
-     'public'        => true,
-     'menu_position' => 5,
-     'supports'      => array( 'title', 'editor', 'thumbnail', 'excerpt', 'comments' ),
-     'has_archive'   => true,
-     'menu_icon' 	=> 'dashicons-text-page',
-   );
-   register_post_type( 'success-story', $args ); 
- }
- add_action( 'init', 'success_story_posts' );
+require get_stylesheet_directory() . '/inc/custom-post-types.php';
+

--- a/inc/custom-post-types.php
+++ b/inc/custom-post-types.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Custom post type definitions.
+ *
+ * @package Petslets
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Register Success Story post type.
+ */
+function petslets_register_success_story_cpt() {
+    $labels = array(
+        'name'               => _x( 'Success Stories', 'post type general name' ),
+        'singular_name'      => _x( 'Success Story', 'post type singular name' ),
+        'add_new'            => _x( 'Add New', 'success story' ),
+        'add_new_item'       => __( 'Add New Success Story' ),
+        'edit_item'          => __( 'Edit Success Story' ),
+        'new_item'           => __( 'New Success Story' ),
+        'all_items'          => __( 'All Success Stories' ),
+        'view_item'          => __( 'View Success Stories' ),
+        'search_items'       => __( 'Search Success Stories' ),
+        'not_found'          => __( 'No Success Stories found' ),
+        'not_found_in_trash' => __( 'No Success Stories found in Trash' ),
+        'menu_name'          => __( 'Success Stories' ),
+    );
+
+    $args = array(
+        'labels'       => $labels,
+        'description'  => 'Our Success Stories',
+        'public'       => true,
+        'menu_position'=> 5,
+        'supports'     => array( 'title', 'editor', 'thumbnail', 'excerpt', 'comments' ),
+        'has_archive'  => true,
+        'menu_icon'    => 'dashicons-text-page',
+        'show_in_rest' => true,
+    );
+
+    register_post_type( 'success-story', $args );
+}
+add_action( 'init', 'petslets_register_success_story_cpt' );
+

--- a/single-success-story.php
+++ b/single-success-story.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all single posts.
+ * The template for displaying Success Story posts.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
@@ -9,11 +9,12 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+    exit; // Exit if accessed directly.
 }
 
-get_header(); ?>
+get_header();
 
-<?php the_content(); ?>
+get_template_part( 'template-parts/content', 'success-story' );
 
-<?php get_footer(); ?>
+get_footer();
+

--- a/template-parts/content-success-story.php
+++ b/template-parts/content-success-story.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Template part for displaying Success Story content.
+ *
+ * @package Petslets
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+    <header class="entry-header">
+        <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+    </header>
+
+    <div class="entry-content">
+        <?php the_content(); ?>
+    </div>
+</article>
+


### PR DESCRIPTION
## Summary
- modularize Success Story custom post type into `inc/custom-post-types.php`
- load custom post types from `functions.php`
- use template part for Success Story singles for cleaner markup

## Testing
- `php -l functions.php inc/custom-post-types.php single-success-story.php template-parts/content-success-story.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3d7db3a388324a9805740f8bce8fd